### PR TITLE
Fix navigation in results page

### DIFF
--- a/src/pages/article-processing-results/index.jsx
+++ b/src/pages/article-processing-results/index.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { useRouter } from 'next/router';
+import { useNavigate } from 'react-router-dom';
 import { Container, Typography, Box, Button, Alert, CircularProgress } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import ResultCard from '@/components/ResultCard';
+import ResultCard from './components/ResultCard';
 
 const ArticleProcessingResults = () => {
-  const router = useRouter();
+  const navigate = useNavigate();
   const [results, setResults] = useState([]);
   const [errors, setErrors] = useState([]);
   const [processedAt, setProcessedAt] = useState('');
@@ -33,7 +33,7 @@ const ArticleProcessingResults = () => {
   }, []);
 
   const handleBackClick = () => {
-    router.push('/article-analysis-dashboard');
+    navigate('/article-analysis-dashboard');
   };
 
   const formatDate = (dateString) => {


### PR DESCRIPTION
## Summary
- switch article processing page to `useNavigate` from React Router
- correct `ResultCard` import path
- update back button navigation

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc3cb449c8325bda0f9bff51e4bfd