### PR TITLE
Switch analyze API to Express

### DIFF
--- a/api/analyze.js
+++ b/api/analyze.js
@@ -1,5 +1,6 @@
 // /api/analyze.js - API endpoint for article analysis
-import { NextResponse } from 'next/server';
+const express = require('express');
+const router = express.Router();
 
 // This would typically use actual NLP services or external APIs
 async function extractArticleContent(url) {
@@ -89,13 +90,12 @@ async function analyzeArticle(articleData) {
   }
 }
 
-export async function POST(request) {
+router.post('/', async (req, res) => {
   try {
-    const body = await request.json();
-    const { urls } = body;
+    const { urls } = req.body;
     
     if (!urls || !Array.isArray(urls) || urls.length === 0) {
-      return NextResponse.json({ error: "No valid URLs provided" }, { status: 400 });
+      return res.status(400).json({ error: "No valid URLs provided" });
     }
     
     // Process each URL
@@ -136,13 +136,15 @@ export async function POST(request) {
     const results = processedResults.filter(result => result.status === "completed");
     const errors = processedResults.filter(result => result.status === "error");
     
-    return NextResponse.json({
+    return res.json({
       results,
       errors,
       processedAt: new Date().toISOString()
     });
   } catch (error) {
     console.error("API error:", error);
-    return NextResponse.json({ error: "Server error" }, { status: 500 });
+    return res.status(500).json({ error: "Server error" });
   }
-}
+});
+
+module.exports = router;

--- a/api/server.js
+++ b/api/server.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const analyzeRouter = require('./analyze');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(express.json());
+app.use('/api/analyze', analyzeRouter);
+
+app.listen(PORT, () => {
+  console.log(`API server running on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
     "redux": "^5.0.1",
     "tailwindcss-animate": "^1.0.7",
     "tailwindcss-elevation": "^2.0.0",
-    "tailwindcss-fluid-type": "^2.0.7"
+    "tailwindcss-fluid-type": "^2.0.7",
+    "express": "^4.18.2"
   },
   "scripts": {
     "start": "vite",
+    "start:api": "node api/server.js",
     "build": "vite build --sourcemap",
     "serve": "vite preview"
   },


### PR DESCRIPTION
## Summary
- switch API response handling from `NextResponse` to Express `res.json`
- export Express router in `api/analyze.js`
- create a small Express server at `api/server.js`
- add Express dependency and script `start:api` to start the server

## Testing
- `npm test` *(fails: Missing script)*
- `node api/server.js` *(fails: Cannot find module 'express')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc3cb84148325b4448b1718e4bbc9