### PR TITLE
Fix results page navigation

### DIFF
--- a/src/pages/article-processing-results/index.jsx
+++ b/src/pages/article-processing-results/index.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Container, Typography, Box, Button, Alert, CircularProgress } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import ResultCard from './components/ResultCard';
+import ResultCard from './components/ResultCard.jsx';
 
 const ArticleProcessingResults = () => {
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- correct ResultCard import path in article results page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685bc5608da483259bdff5335510ab15